### PR TITLE
Fix URL to Morty otherwise Searx tries to connect to http://morty

### DIFF
--- a/searx/docker-compose.searx.yml
+++ b/searx/docker-compose.searx.yml
@@ -14,7 +14,7 @@ services:
     environment:
       - 'BIND_ADDRESS=0.0.0.0:8080'
       - 'BASE_URL=https://searx.${SITE:-localhost}/'
-      - 'MORTY_URL=http://morty/'
+      - 'MORTY_URL=https://morty.${SITE:-localhost}/'
       - 'MORTY_KEY=${MORTY_KEY:-VGhpcyBrZXkgaXMgTk9UIHNlY3VyZQ==}'
     depends_on:
       - morty


### PR DESCRIPTION
I'm not entirely sure if this is correct, but with `MORTY_URL=http://morty/` my Searx instance is really trying to connect to `http://morty`, which obviously fails, and this fixes it, but I'm not sure if it's intended the way it is now...

Thanks for this awesome list of services btw :pray:! 