### PR TITLE
Self build tor-relay image as the docker hub repo isn't regular updated

### DIFF
--- a/test_config.yml
+++ b/test_config.yml
@@ -977,6 +977,8 @@ services:
     volumes:
     - /home/runner:/home/project:cached
   tor-relay:
+    build:
+      context: https://github.com/jessfraz/dockerfiles.git#:tor-relay
     command: -f /etc/tor/torrc.middle
     image: jess/tor-relay
     labels:

--- a/tor-relay/docker-compose.tor-relay.yml
+++ b/tor-relay/docker-compose.tor-relay.yml
@@ -6,6 +6,7 @@ version: '2'
 services:
   tor-relay:
     image: jess/tor-relay
+    build: https://github.com/jessfraz/dockerfiles.git#:tor-relay
     # Choose one of the bellow to set the type of node
     # command: -f /etc/tor/torrc.bridge
     command: -f /etc/tor/torrc.middle


### PR DESCRIPTION
Tor otherwise complains about outdated versions