### PR TITLE
Add streaming API base URL to prevent websocket connection problem

### DIFF
--- a/mastodon/.env.production
+++ b/mastodon/.env.production
@@ -9,6 +9,7 @@
 # This identifies your server and cannot be changed safely later
 # ----------
 LOCAL_DOMAIN=mastodon.example.com
+STREAMING_API_BASE_URL=wss://mastodon-streaming.example.com
 
 # Redis
 # -----

--- a/test_config.yml
+++ b/test_config.yml
@@ -401,6 +401,7 @@ services:
       SMTP_PASSWORD: ''
       SMTP_PORT: '587'
       SMTP_SERVER: smtp.mailgun.org
+      STREAMING_API_BASE_URL: wss://mastodon-streaming.example.com
       VAPID_PRIVATE_KEY: ''
       VAPID_PUBLIC_KEY: ''
     healthcheck:
@@ -481,6 +482,7 @@ services:
       SMTP_PASSWORD: ''
       SMTP_PORT: '587'
       SMTP_SERVER: smtp.mailgun.org
+      STREAMING_API_BASE_URL: wss://mastodon-streaming.example.com
       VAPID_PRIVATE_KEY: ''
       VAPID_PUBLIC_KEY: ''
     image: tootsuite/mastodon
@@ -521,6 +523,7 @@ services:
       SMTP_PASSWORD: ''
       SMTP_PORT: '587'
       SMTP_SERVER: smtp.mailgun.org
+      STREAMING_API_BASE_URL: wss://mastodon-streaming.example.com
       VAPID_PRIVATE_KEY: ''
       VAPID_PUBLIC_KEY: ''
     healthcheck:


### PR DESCRIPTION
As we set in 

https://github.com/tomMoulard/make-my-server/blob/44c36b82a41a6e7c39d103b1ed126ed3fb9268fa/mastodon/docker-compose.mastodon.yml#L71

a sub domain for the streaming websocket, we need to provide the URL via `STREAMING_API_BASE_URL` too, otherwise the browser tries to connect to `wss://mastodon.example.com` which obviously fails.

See https://docs.joinmastodon.org/admin/config/#streaming-api-base-url for more information.