### PR TITLE
Fix Jellyfin service which crashes on startup

### DIFF
--- a/jellyfin/docker-compose.jellyfin.yml
+++ b/jellyfin/docker-compose.jellyfin.yml
@@ -11,7 +11,6 @@ services:
     networks:
       - 'srv'
     restart: always
-    user: 1000:1000
     labels:
       - 'traefik.enable=true'
       - 'traefik.http.routers.jellyfin.rule=Host(`jellyfin.${SITE:-localhost}`)'

--- a/test_config.yml
+++ b/test_config.yml
@@ -316,7 +316,6 @@ services:
     networks:
       srv: {}
     restart: always
-    user: 1000:1000
     volumes:
     - /home/runner/work/make-my-server/make-my-server/jellyfin/cache:/cache:rw
     - /home/runner/work/make-my-server/make-my-server/jellyfin/config:/config:rw


### PR DESCRIPTION
Setting user is deprecated and leads to crash during startup. See https://github.com/jellyfin/jellyfin/issues/306#issuecomment-450487606 for further information.